### PR TITLE
feat!: format output message

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pause_console"
-version = "0.1.3"
+version = "0.2.0"
 authors = ["Andrii Semenystyi <meowningmaster@gmail.com>"]
 edition = "2018"
 

--- a/Readme.md
+++ b/Readme.md
@@ -1,17 +1,21 @@
 # Description
+
 Crate that brings functionality similar to c++'s `system("pause")`
 
 # Usage
-```rust
-use pause_console::*;
-...
 
-//print "Press Enter to continue..." then wait till Enter pressed
+```rust
+use pause_console::pause_console;
+
+// print "Press Enter to continue..." then wait till Enter pressed
 pause_console!();
 
-//same with custom message
+// same with custom message
 pause_console!("Sample message");
 
-//same with newlines
+// same with newlines
 pause_console!("\nSample message\n");
+
+// and you can format and output message
+pause_console!("Sample message: {}", 1);
 ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,20 +1,13 @@
-use std::io::{stdin, stdout, Write};
-
-pub const PAUSE_CONSOLE_DEFAULT_MESSAGE: &str = "Press Enter to continue...";
-
-pub fn pause_console_execute(message: &str) {
-    let mut stdout = stdout();
-    stdout.write(message.as_bytes()).unwrap();
-    stdout.flush().unwrap();
-    stdin().read_line(&mut String::new()).unwrap();
-}
-
 #[macro_export]
 macro_rules! pause_console {
-    ($message: expr) => {
-        pause_console_execute($message);
-    };
     () => {
-        pause_console_execute(PAUSE_CONSOLE_DEFAULT_MESSAGE);
+        std::print!("Press Enter to continue...");
+        std::io::Write::flush(&mut std::io::stdout()).unwrap();
+        std::io::stdin().read_line(&mut String::new()).unwrap();
+    };
+    ($($arg:tt)*) => {
+        std::print!($($arg)*);
+        std::io::Write::flush(&mut std::io::stdout()).unwrap();
+        std::io::stdin().read_line(&mut String::new()).unwrap();
     };
 }


### PR DESCRIPTION
This pull request changed the argument for `pause_console` macro.
Before, `pause_console` macro only can use a `&str` argument
Now, `pause_console` macro can use the same as `print` macro's arguments

BREAKING CHANGE: Remove `pause_console_execute` function
BREAKING CHANGE: Remove `PAUSE_CONSOLE_DEFAULT_MESSAGE` static variable